### PR TITLE
Update fork to latest upstream (2.2.2)

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,0 +1,32 @@
+name: Terraform CI
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Run a Terraform init
+        uses: docker://hashicorp/terraform:light
+        with:
+          entrypoint: terraform
+          args: init
+
+      - name: Run a Terraform validate
+        uses: docker://hashicorp/terraform:light
+        with:
+          entrypoint: terraform
+          args: validate
+
+      - name: Run a Terraform fmt
+        uses: docker://hashicorp/terraform:light
+        with:
+          entrypoint: terraform
+          args: fmt  --recursive -check=true --diff

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,14 +21,14 @@ jobs:
 
       - name: Run a Terraform validate
         uses: docker://hashicorp/terraform:light
+        env:
+          AWS_DEFAULT_REGION: eu-east-1
         with:
           entrypoint: terraform
           args: validate
 
       - name: Run a Terraform fmt
         uses: docker://hashicorp/terraform:light
-        env:
-          AWS_DEFAULT_REGION: eu-east-1
         with:
           entrypoint: terraform
           args: fmt  --recursive -check=true --diff

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Run a Terraform fmt
         uses: docker://hashicorp/terraform:light
+        env:
+          AWS_DEFAULT_REGION: eu-east-1
         with:
           entrypoint: terraform
           args: fmt  --recursive -check=true --diff

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ module "bastion" {
   "vpc_id" = "my_vpc_id"
   "is_lb_private" = "true|false"
   "bastion_host_key_pair" = "my_key_pair"
+  "create_dns_record" = "true|false"
   "hosted_zone_id" = "my.hosted.zone.name."
   "bastion_record_name" = "bastion.my.hosted.zone.name."
   "bastion_iam_policy_name" = "myBastionHostPolicy"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ module "bastion" {
 | bucket_name |  |
 | bucket_name | The name of the bucket where logs are sent |
 | elb_ip | The ELB DNS Name for the Bastion Host instances |
-| bastion_host_security_group_id | The security group ID of the Bastion Host |
+| bastion_host_security_group | The security group ID of the Bastion Host |
 | private_instances_security_group | The security group ID of the the private instances that allow Bastion SSH ingress |
 
 Known issues

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ module "bastion" {
 | cidrs | List of CIDRs than can access to the bastion. Default : 0.0.0.0/0 | list | `<list>` | no |
 | create_dns_record | Choose if you want to create a record name for the bastion (LB). If true 'hosted_zone_name' and 'bastion_record_name' are mandatory | integer | - | yes |
 | elb_subnets | List of subnet were the ELB will be deployed | list | - | yes |
+| extra_user_data_content | Additional scripting to pass to the bastion host. For example, this can include installing postgresql for the `psql` command. | string | `""` | no |
 | hosted_zone_name | Name of the hosted zone were we'll register the bastion DNS name | string | `` | no |
 | is_lb_private | If TRUE the load balancer scheme will be "internal" else "internet-facing" | string | - | yes |
 | log_auto_clean | Enable or not the lifecycle | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ module "bastion" {
 | Name | Description |
 |------|-------------|
 | bucket_name |  |
-| elb_ip |  |
+| bucket_name | The name of the bucket where logs are sent |
+| elb_ip | The ELB DNS Name for the Bastion Host instances |
+| bastion_host_security_group_id | The security group ID of the Bastion Host |
+| private_instances_security_group | The security group ID of the the private instances that allow Bastion SSH ingress |
 
 Known issues
 ------------

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ module "bastion" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | auto_scaling_group_subnets | List of subnet were the Auto Scalling Group will deploy the instances | list | - | yes |
+| allow_ssh_commands | Allows the SSH user to execute one-off commands. Pass 'True' to enable. Warning: These commands are not logged and increase the vulnerability of the system. Use at your own discretion. | string | "" | no |
 | bastion_amis |  | map | `<map>` | no |
 | bastion_host_key_pair | Select the key pair to use to launch the bastion host | string | - | yes |
 | bastion_instance_count | Count of bastion instance created on VPC | string | `1` | no |

--- a/README.md
+++ b/README.md
@@ -1,101 +1,59 @@
-AWS Bastion Terraform module
-===========================================
+# Requirements
 
-[![Open Source Helpers](https://www.codetriage.com/guimove/terraform-aws-bastion/badges/users.svg)](https://www.codetriage.com/guimove/terraform-aws-bastion)
+No requirements.
 
-Terraform module which creates a secure SSH bastion on AWS.
+## Providers
 
-Mainly inspired by [Securely Connect to Linux Instances Running in a Private Amazon VPC](https://aws.amazon.com/blogs/security/securely-connect-to-linux-instances-running-in-a-private-amazon-vpc/)
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| null | n/a |
+| template | n/a |
 
-Features
---------
-
-This module will create an SSH bastion to securely connect in SSH  to your private instances.
-![Bastion Infrastrucutre](https://raw.githubusercontent.com/Guimove/terraform-aws-bastion/master/_docs/terraformawsbastion.png)
-All SSH  commands are logged on an S3 bucket for security compliance, in the /logs path.
-
-SSH  users are managed by their public key, simply drop the SSH key of the user in  the /public-keys path of the bucket.
-Keys should be named like 'username.pub', this will create the user 'username' on the bastion server.
-
-Then after you'll be able to connect to the server with : 
-
-```
-ssh [-i path_to_the_private_key] username@bastion-dns-name
-```
-
-From this bastion server, you'll able to connect to all instances on the private subnet. 
-
-If there is a missing feature or a bug - [open an issue](https://github.com/Guimove/terraform-aws-bastion/issues/new).
-
-Usage
------
-
-```hcl
-module "bastion" {
-  "source" = "terraform-aws-modules/bastion/aws"
-  "bucket_name" = "my_famous_bucket_name"
-  "region" = "eu-west-1"
-  "vpc_id" = "my_vpc_id"
-  "is_lb_private" = "true|false"
-  "bastion_host_key_pair" = "my_key_pair"
-  "hosted_zone_id" = "my.hosted.zone.name."
-  "bastion_record_name" = "bastion.my.hosted.zone.name."
-  "bastion_iam_policy_name" = "myBastionHostPolicy"
-  "elb_subnets" = [
-    "subnet-id1a",
-    "subnet-id1b"
-  ]
-  "auto_scaling_group_subnets" = [
-    "subnet-id1a",
-    "subnet-id1b"
-  ]
-  tags = {
-    "name" = "my_bastion_name",
-    "description" = "my_bastion_description"
-  }
-}
-```
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| auto_scaling_group_subnets | List of subnet were the Auto Scalling Group will deploy the instances | list | - | yes |
-| allow_ssh_commands | Allows the SSH user to execute one-off commands. Pass 'True' to enable. Warning: These commands are not logged and increase the vulnerability of the system. Use at your own discretion. | string | "" | no |
-| bastion_host_key_pair | Select the key pair to use to launch the bastion host | string | - | yes |
-| bastion_instance_count | Count of bastion instance created on VPC | string | `1` | no |
-| bastion_launch_configuration_name | Bastion Launch configuration Name, will also be used for the ASG | string | `lc` | no |
-| bastion_ami | The AMI that the Bastion Host will use. If not supplied, the latest Amazon2 AMI will be used. | string | `` | no |
-| bastion_record_name | DNS record name to use for the bastion | string | `` | no |
-| bastion_host_policy_name | IAM Policy Name to create for the bastion instance role | string | `BastionHost` | no |
-| bucket_name | Bucket name were the bastion will store the logs | string | - | yes |
-| bucket_force_destroy | On destroy, bucket and all objects should be destroyed when using true | string | false | no |
-| bucket_versioning | Enable bucket versioning or not | string | true | no |
-| cidrs | List of CIDRs than can access to the bastion. Default : 0.0.0.0/0 | list | `<list>` | no |
-| create_dns_record | Choose if you want to create a record name for the bastion (LB). If true 'hosted_zone_id' and 'bastion_record_name' are mandatory | integer | - | yes |
-| elb_subnets | List of subnet were the ELB will be deployed | list | - | yes |
-| extra_user_data_content | Additional scripting to pass to the bastion host. For example, this can include installing postgresql for the `psql` command. | string | `""` | no |
-| hosted_zone_id | Name of the hosted zone were we'll register the bastion DNS name | string | `` | no |
-| instance_type | Instance size of the bastion | `string` | `"t3.nano"` | no |
-| is_lb_private | If TRUE the load balancer scheme will be "internal" else "internet-facing" | string | - | yes |
-| log_auto_clean | Enable or not the lifecycle | string | `false` | no |
-| log_expiry_days | Number of days before logs expiration | string | `90` | no |
-| log_glacier_days | Number of days before moving logs to Glacier | string | `60` | no |
-| log_standard_ia_days | Number of days before moving logs to IA Storage | string | `30` | no |
-| private_ssh_port | Set the SSH port to use between the bastion and private instance | string | `22` | no |
-| public_ssh_port | Set the SSH port to use from desktop to the bastion | string | `22` | no |
-| region |  | string | - | yes |
-| tags | A mapping of tags to assign | map | `<map>` | no |
-| vpc_id | VPC id were we'll deploy the bastion | string | - | yes |
+|------|-------------|------|---------|:--------:|
+| allow\_ssh\_commands | Allows the SSH user to execute one-off commands. Pass 'True' to enable. Warning: These commands are not logged and increase the vulnerability of the system. Use at your own discretion. | `string` | `""` | no |
+| associate\_public\_ip\_address | Wether or not to associate a public ip | `bool` | `true` | no |
+| auto\_scaling\_group\_subnets | List of subnet were the Auto Scalling Group will deploy the instances | `list(string)` | n/a | yes |
+| bastion\_ami | The AMI that the Bastion Host will use. | `string` | `""` | no |
+| bastion\_host\_key\_pair | Select the key pair to use to launch the bastion host | `any` | n/a | yes |
+| bastion\_iam\_policy\_name | IAM policy name to create for granting the instance role access to the bucket | `string` | `"BastionHost"` | no |
+| bastion\_instance\_count | Number of instances to create | `number` | `1` | no |
+| bastion\_launch\_template\_name | Bastion Launch template Name, will also be used for the ASG | `string` | `"bastion-lt"` | no |
+| bastion\_record\_name | DNS record name to use for the bastion | `string` | `""` | no |
+| bucket\_force\_destroy | The bucket and all objects should be destroyed when using true | `bool` | `false` | no |
+| bucket\_name | Bucket name were the bastion will store the logs | `any` | n/a | yes |
+| bucket\_versioning | Enable bucket versioning or not | `bool` | `true` | no |
+| cidrs | List of CIDRs than can access to the bastion. Default : 0.0.0.0/0 | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| create\_dns\_record | Choose if you want to create a record name for the bastion (LB). If true 'hosted\_zone\_id' and 'bastion\_record\_name' are mandatory | `any` | n/a | yes |
+| elb\_subnets | List of subnet were the ELB will be deployed | `list(string)` | n/a | yes |
+| extra\_user\_data\_content | Additional scripting to pass to the bastion host. For example, this can include installing postgresql for the `psql` command. | `string` | `""` | no |
+| hosted\_zone\_id | Name of the hosted zone were we'll register the bastion DNS name | `string` | `""` | no |
+| instance\_type | Instance size of the bastion | `string` | `"t3.nano"` | no |
+| is\_lb\_private | If TRUE the load balancer scheme will be "internal" else "internet-facing" | `any` | n/a | yes |
+| log\_auto\_clean | Enable or not the lifecycle | `bool` | `false` | no |
+| log\_expiry\_days | Number of days before logs expiration | `number` | `90` | no |
+| log\_glacier\_days | Number of days before moving logs to Glacier | `number` | `60` | no |
+| log\_standard\_ia\_days | Number of days before moving logs to IA Storage | `number` | `30` | no |
+| private\_ssh\_port | Set the SSH port to use between the bastion and private instance | `number` | `22` | no |
+| public\_ssh\_port | Set the SSH port to use from desktop to the bastion | `number` | `22` | no |
+| region | AWS Region | `any` | n/a | yes |
+| tags | A mapping of tags to assign | `map(string)` | `{}` | no |
+| vpc\_id | VPC id were we'll deploy the bastion | `any` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| bucket_name |  |
-| bucket_name | The name of the bucket where logs are sent |
-| elb_ip | The ELB DNS Name for the Bastion Host instances |
-| bastion_host_security_group | The security group ID of the Bastion Host |
-| private_instances_security_group | The security group ID of the the private instances that allow Bastion SSH ingress |
+| bastion\_host\_security\_group | The security group ID of the Bastion Host |
+| bucket\_kms\_key\_alias | The alias of the buckets kms key |
+| bucket\_kms\_key\_arn | The arn of the buckets kms key |
+| bucket\_name | The name of the bucket where logs are sent |
+| elb\_ip | The ELB DNS Name for the Bastion Host instances |
+| private\_instances\_security\_group | The security group ID of the the private instances that allow Bastion SSH ingress |
+
 
 Known issues
 ------------

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ module "bastion" {
 | bastion_launch_configuration_name | Bastion Launch configuration Name, will also be used for the ASG | string | `lc` | no |
 | bastion_ami | The AMI that the Bastion Host will use. If not supplied, the latest Amazon2 AMI will be used. | string | `` | no |
 | bastion_record_name | DNS record name to use for the bastion | string | `` | no |
-| bastion_host_policy_name | IAM Policy Name to create for the bastion ibnstance role | string | `BastionHost` | no |
+| bastion_host_policy_name | IAM Policy Name to create for the bastion instance role | string | `BastionHost` | no |
 | bucket_name | Bucket name were the bastion will store the logs | string | - | yes |
 | bucket_force_destroy | On destroy, bucket and all objects should be destroyed when using true | string | false | no |
 | bucket_versioning | Enable bucket versioning or not | string | true | no |
@@ -75,6 +75,7 @@ module "bastion" {
 | elb_subnets | List of subnet were the ELB will be deployed | list | - | yes |
 | extra_user_data_content | Additional scripting to pass to the bastion host. For example, this can include installing postgresql for the `psql` command. | string | `""` | no |
 | hosted_zone_id | Name of the hosted zone were we'll register the bastion DNS name | string | `` | no |
+| instance_type | Instance size of the bastion | `string` | `"t3.nano"` | no |
 | is_lb_private | If TRUE the load balancer scheme will be "internal" else "internet-facing" | string | - | yes |
 | log_auto_clean | Enable or not the lifecycle | string | `false` | no |
 | log_expiry_days | Number of days before logs expiration | string | `90` | no |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage
 
 ```hcl
 module "bastion" {
-  "source" = "terraform-aws-modules/bastion/aws"
+  "source" = "Guimove/bastion/aws"
   "bucket_name" = "my_famous_bucket_name"
   "region" = "eu-west-1"
   "vpc_id" = "my_vpc_id"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ module "bastion" {
   "bastion_host_key_pair" = "my_key_pair"
   "hosted_zone_id" = "my.hosted.zone.name."
   "bastion_record_name" = "bastion.my.hosted.zone.name."
+  "bastion_iam_policy_name" = "myBastionHostPolicy"
   "elb_subnets" = [
     "subnet-id1a",
     "subnet-id1b"
@@ -65,6 +66,7 @@ module "bastion" {
 | bastion_launch_configuration_name | Bastion Launch configuration Name, will also be used for the ASG | string | `lc` | no |
 | bastion_ami | The AMI that the Bastion Host will use. If not supplied, the latest Amazon2 AMI will be used. | string | `` | no |
 | bastion_record_name | DNS record name to use for the bastion | string | `` | no |
+| bastion_host_policy_name | IAM Policy Name to create for the bastion ibnstance role | string | `BastionHost` | no |
 | bucket_name | Bucket name were the bastion will store the logs | string | - | yes |
 | bucket_force_destroy | On destroy, bucket and all objects should be destroyed when using true | string | false | no |
 | bucket_versioning | Enable bucket versioning or not | string | true | no |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module "bastion" {
   "vpc_id" = "my_vpc_id"
   "is_lb_private" = "true|false"
   "bastion_host_key_pair" = "my_key_pair"
-  "hosted_zone_name" = "my.hosted.zone.name."
+  "hosted_zone_id" = "my.hosted.zone.name."
   "bastion_record_name" = "bastion.my.hosted.zone.name."
   "elb_subnets" = [
     "subnet-id1a",
@@ -67,9 +67,9 @@ module "bastion" {
 | bucket_force_destroy | On destroy, bucket and all objects should be destroyed when using true | string | false | no |
 | bucket_versioning | Enable bucket versioning or not | string | true | no |
 | cidrs | List of CIDRs than can access to the bastion. Default : 0.0.0.0/0 | list | `<list>` | no |
-| create_dns_record | Choose if you want to create a record name for the bastion (LB). If true 'hosted_zone_name' and 'bastion_record_name' are mandatory | integer | - | yes |
+| create_dns_record | Choose if you want to create a record name for the bastion (LB). If true 'hosted_zone_id' and 'bastion_record_name' are mandatory | integer | - | yes |
 | elb_subnets | List of subnet were the ELB will be deployed | list | - | yes |
-| hosted_zone_name | Name of the hosted zone were we'll register the bastion DNS name | string | `` | no |
+| hosted_zone_id | Name of the hosted zone were we'll register the bastion DNS name | string | `` | no |
 | is_lb_private | If TRUE the load balancer scheme will be "internal" else "internet-facing" | string | - | yes |
 | log_auto_clean | Enable or not the lifecycle | string | `false` | no |
 | log_expiry_days | Number of days before logs expiration | string | `90` | no |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,61 @@
+AWS Bastion Terraform module
+===========================================
+
+[![Open Source Helpers](https://www.codetriage.com/guimove/terraform-aws-bastion/badges/users.svg)](https://www.codetriage.com/guimove/terraform-aws-bastion)
+
+Terraform module which creates a secure SSH bastion on AWS.
+
+Mainly inspired by [Securely Connect to Linux Instances Running in a Private Amazon VPC](https://aws.amazon.com/blogs/security/securely-connect-to-linux-instances-running-in-a-private-amazon-vpc/)
+
+Features
+--------
+
+This module will create an SSH bastion to securely connect in SSH  to your private instances.
+![Bastion Infrastrucutre](https://raw.githubusercontent.com/Guimove/terraform-aws-bastion/master/_docs/terraformawsbastion.png)
+All SSH  commands are logged on an S3 bucket for security compliance, in the /logs path.
+
+SSH  users are managed by their public key, simply drop the SSH key of the user in  the /public-keys path of the bucket.
+Keys should be named like 'username.pub', this will create the user 'username' on the bastion server.
+
+Then after you'll be able to connect to the server with : 
+
+```
+ssh [-i path_to_the_private_key] username@bastion-dns-name
+```
+
+From this bastion server, you'll able to connect to all instances on the private subnet. 
+
+If there is a missing feature or a bug - [open an issue](https://github.com/Guimove/terraform-aws-bastion/issues/new).
+
+Usage
+-----
+
+```hcl
+module "bastion" {
+  "source" = "terraform-aws-modules/bastion/aws"
+  "bucket_name" = "my_famous_bucket_name"
+  "region" = "eu-west-1"
+  "vpc_id" = "my_vpc_id"
+  "is_lb_private" = "true|false"
+  "bastion_host_key_pair" = "my_key_pair"
+  "hosted_zone_id" = "my.hosted.zone.name."
+  "bastion_record_name" = "bastion.my.hosted.zone.name."
+  "bastion_iam_policy_name" = "myBastionHostPolicy"
+  "elb_subnets" = [
+    "subnet-id1a",
+    "subnet-id1b"
+  ]
+  "auto_scaling_group_subnets" = [
+    "subnet-id1a",
+    "subnet-id1b"
+  ]
+  tags = {
+    "name" = "my_bastion_name",
+    "description" = "my_bastion_description"
+  }
+}
+```
+
 # Requirements
 
 No requirements.
@@ -53,7 +111,6 @@ No requirements.
 | bucket\_name | The name of the bucket where logs are sent |
 | elb\_ip | The ELB DNS Name for the Bastion Host instances |
 | private\_instances\_security\_group | The security group ID of the the private instances that allow Bastion SSH ingress |
-
 
 Known issues
 ------------

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ module "bastion" {
 |------|-------------|:----:|:-----:|:-----:|
 | auto_scaling_group_subnets | List of subnet were the Auto Scalling Group will deploy the instances | list | - | yes |
 | allow_ssh_commands | Allows the SSH user to execute one-off commands. Pass 'True' to enable. Warning: These commands are not logged and increase the vulnerability of the system. Use at your own discretion. | string | "" | no |
-| bastion_amis |  | map | `<map>` | no |
 | bastion_host_key_pair | Select the key pair to use to launch the bastion host | string | - | yes |
 | bastion_instance_count | Count of bastion instance created on VPC | string | `1` | no |
+| bastion_launch_configuration_name | Bastion Launch configuration Name, will also be used for the ASG | string | `lc` | no |
+| bastion_ami | The AMI that the Bastion Host will use. If not supplied, the latest Amazon2 AMI will be used. | string | `` | no |
 | bastion_record_name | DNS record name to use for the bastion | string | `` | no |
 | bucket_name | Bucket name were the bastion will store the logs | string | - | yes |
 | bucket_force_destroy | On destroy, bucket and all objects should be destroyed when using true | string | false | no |

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   tags_asg_format = null_resource.tags_as_list_of_maps.*.triggers
 
-  name_prefix = var.bastion_launch_configuration_name
+  name_prefix = var.bastion_launch_template_name
 }
 
 resource "null_resource" "tags_as_list_of_maps" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   tags_asg_format = null_resource.tags_as_list_of_maps.*.triggers
 
-  name_prefix = var.bastion_launch_template_name
+  name_prefix    = var.bastion_launch_template_name
   security_group = join("", flatten([aws_security_group.bastion_host_security_group[*].id, var.bastion_security_group_id]))
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -2,6 +2,7 @@ locals {
   tags_asg_format = null_resource.tags_as_list_of_maps.*.triggers
 
   name_prefix = var.bastion_launch_template_name
+  security_group = join("", flatten([aws_security_group.bastion_host_security_group[*].id, var.bastion_security_group_id]))
 }
 
 resource "null_resource" "tags_as_list_of_maps" {

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_kms_alias" "alias" {
 
 resource "aws_s3_bucket" "bucket" {
   bucket = var.bucket_name
-  acl    = "bucket-owner-full-control"
+  acl    = "private"
 
   server_side_encryption_configuration {
     rule {

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,7 @@ EOF
 
 resource "aws_route53_record" "bastion_record_name" {
   name    = var.bastion_record_name
-  zone_id = var.hosted_zone_name
+  zone_id = var.hosted_zone_id
   type    = "A"
   count   = var.create_dns_record ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -238,7 +238,7 @@ resource "aws_iam_instance_profile" "bastion_host_profile" {
 resource "aws_launch_configuration" "bastion_launch_configuration" {
   name_prefix                 = var.bastion_launch_configuration_name
   image_id                    = data.aws_ami.amazon-linux-2.id
-  instance_type               = "t2.nano"
+  instance_type               = "t3.nano"
   associate_public_ip_address = var.associate_public_ip_address
   enable_monitoring           = true
   iam_instance_profile        = aws_iam_instance_profile.bastion_host_profile.name

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "aws_s3_bucket_object" "bucket_public_keys_readme" {
   bucket  = aws_s3_bucket.bucket.id
   key     = "public-keys/README.txt"
   content = "Drop here the ssh public keys of the instances you want to control"
+  kms_key_id = aws_kms_key.key.id
 }
 
 resource "aws_security_group" "bastion_host_security_group" {

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,9 @@ data "template_file" "user_data" {
   template = file("${path.module}/user_data.sh")
 
   vars = {
-    aws_region  = var.region
-    bucket_name = var.bucket_name
+    aws_region              = var.region
+    bucket_name             = var.bucket_name
+    extra_user_data_content = var.extra_user_data_content
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -220,7 +220,7 @@ resource "aws_iam_instance_profile" "bastion_host_profile" {
 
 resource "aws_launch_configuration" "bastion_launch_configuration" {
   name_prefix                 = var.bastion_launch_configuration_name
-  image_id                    = data.aws_ami.amazon-linux-2.id
+  image_id                    = var.bastion_ami != "" ? var.bastion_ami : data.aws_ami.amazon-linux-2.id
   instance_type               = "t2.nano"
   associate_public_ip_address = var.associate_public_ip_address
   enable_monitoring           = true

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "aws_s3_bucket_object" "bucket_public_keys_readme" {
   bucket  = aws_s3_bucket.bucket.id
   key     = "public-keys/README.txt"
   content = "Drop here the ssh public keys of the instances you want to control"
-  kms_key_id = aws_kms_key.key.id
+  kms_key_id = aws_kms_key.key.arn
 }
 
 resource "aws_security_group" "bastion_host_security_group" {

--- a/main.tf
+++ b/main.tf
@@ -317,4 +317,6 @@ resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
   lifecycle {
     create_before_destroy = true
   }
+
+  depends_on = ["aws_s3_bucket.bucket"]
 }

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ data "template_file" "user_data" {
     bucket_name             = var.bucket_name
     extra_user_data_content = var.extra_user_data_content
     allow_ssh_commands      = var.allow_ssh_commands
+    public_ssh_port         = var.public_ssh_port
   }
 }
 
@@ -115,8 +116,8 @@ resource "aws_security_group" "private_instances_security_group" {
 resource "aws_security_group_rule" "ingress_instances" {
   description = "Incoming traffic from bastion"
   type        = "ingress"
-  from_port   = var.public_ssh_port
-  to_port     = var.public_ssh_port
+  from_port   = var.private_ssh_port
+  to_port     = var.private_ssh_port
   protocol    = "TCP"
 
   source_security_group_id = aws_security_group.bastion_host_security_group.id

--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,15 @@ data "aws_iam_policy_document" "bastion_host_policy_document" {
 
 }
 
+resource "aws_iam_policy" "bastion_host_policy" {
+  name   = "BastionHost"
+  policy = data.aws_iam_policy_document.bastion_host_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "bastion_host" {
+  policy_arn = aws_iam_policy.bastion_host_policy.arn
+  role       = aws_iam_role.bastion_host_role.name
+}
 
 resource "aws_route53_record" "bastion_record_name" {
   name    = var.bastion_record_name

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ data "template_file" "user_data" {
     aws_region              = var.region
     bucket_name             = var.bucket_name
     extra_user_data_content = var.extra_user_data_content
+    allow_ssh_commands      = var.allow_ssh_commands
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,28 @@ data "template_file" "user_data" {
   }
 }
 
+resource "aws_kms_key" "key" {
+  tags = merge(var.tags)
+}
+
+resource "aws_kms_alias" "alias" {
+  name          = "alias/${var.bucket_name}"
+  target_key_id = aws_kms_key.key.arn
+}
+
 resource "aws_s3_bucket" "bucket" {
   bucket = var.bucket_name
   acl    = "bucket-owner-full-control"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.key.id
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
 
   force_destroy = var.bucket_force_destroy
 

--- a/main.tf
+++ b/main.tf
@@ -184,7 +184,7 @@ data "aws_iam_policy_document" "bastion_host_policy_document" {
 }
 
 resource "aws_iam_policy" "bastion_host_policy" {
-  name   = "BastionHost"
+  name   = var.bastion_iam_policy_name
   policy = data.aws_iam_policy_document.bastion_host_policy_document.json
 }
 

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ resource "aws_kms_key" "key" {
 }
 
 resource "aws_kms_alias" "alias" {
-  name          = "alias/${replace("${var.bucket_name}", ".", "_")}"
+  name          = "alias/${replace(var.bucket_name, ".", "_")}"
   target_key_id = aws_kms_key.key.arn
 }
 
@@ -318,5 +318,5 @@ resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
     create_before_destroy = true
   }
 
-  depends_on = ["aws_s3_bucket.bucket"]
+  depends_on = [aws_s3_bucket.bucket]
 }

--- a/main.tf
+++ b/main.tf
@@ -163,9 +163,9 @@ data "aws_iam_policy_document" "bastion_host_policy_document" {
     aws_s3_bucket.bucket.arn]
 
     condition {
-      test     = "StringEquals"
-      values   = ["s3:prefix"]
-      variable = "public-keys/"
+      test     = "ForAnyValue:StringEquals"
+      values   = ["public-keys/"]
+      variable = "s3:prefix"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ resource "aws_kms_key" "key" {
 }
 
 resource "aws_kms_alias" "alias" {
-  name          = "alias/${var.bucket_name}"
+  name          = "alias/${replace("${var.bucket_name}", ".", "_")}"
   target_key_id = aws_kms_key.key.arn
 }
 
@@ -69,9 +69,9 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_object" "bucket_public_keys_readme" {
-  bucket  = aws_s3_bucket.bucket.id
-  key     = "public-keys/README.txt"
-  content = "Drop here the ssh public keys of the instances you want to control"
+  bucket     = aws_s3_bucket.bucket.id
+  key        = "public-keys/README.txt"
+  content    = "Drop here the ssh public keys of the instances you want to control"
   kms_key_id = aws_kms_key.key.arn
 }
 

--- a/main.tf
+++ b/main.tf
@@ -250,7 +250,7 @@ resource "aws_iam_instance_profile" "bastion_host_profile" {
 resource "aws_launch_template" "bastion_launch_template" {
   name_prefix   = local.name_prefix
   image_id      = var.bastion_ami != "" ? var.bastion_ami : data.aws_ami.amazon-linux-2.id
-  instance_type = "t3.nano"
+  instance_type = var.instance_type
   monitoring {
     enabled = true
   }

--- a/main.tf
+++ b/main.tf
@@ -216,20 +216,34 @@ resource "aws_iam_instance_profile" "bastion_host_profile" {
   path = "/"
 }
 
-resource "aws_launch_configuration" "bastion_launch_configuration" {
-  name_prefix                 = var.bastion_launch_configuration_name
-  image_id                    = data.aws_ami.amazon-linux-2.id
-  instance_type               = "t2.nano"
-  associate_public_ip_address = var.associate_public_ip_address
-  enable_monitoring           = true
-  iam_instance_profile        = aws_iam_instance_profile.bastion_host_profile.name
-  key_name                    = var.bastion_host_key_pair
+resource "aws_launch_template" "bastion_launch_template" {
+  name_prefix   = local.name_prefix
+  image_id      = data.aws_ami.amazon-linux-2.id
+  instance_type = "t2.nano"
+  monitoring {
+    enabled = true
+  }
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ip_address
+    security_groups             = [aws_security_group.bastion_host_security_group.id]
+    delete_on_termination       = true
+  }
+  iam_instance_profile {
+    name = aws_iam_instance_profile.bastion_host_profile.name
+  }
+  key_name = var.bastion_host_key_pair
 
-  security_groups = [
-    aws_security_group.bastion_host_security_group.id,
-  ]
+  user_data = base64encode(data.template_file.user_data.rendered)
 
-  user_data = data.template_file.user_data.rendered
+  tag_specifications {
+    resource_type = "instance"
+    tags          = merge(map("Name", var.bastion_launch_template_name), merge(var.tags))
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags          = merge(map("Name", var.bastion_launch_template_name), merge(var.tags))
+  }
 
   lifecycle {
     create_before_destroy = true
@@ -237,11 +251,14 @@ resource "aws_launch_configuration" "bastion_launch_configuration" {
 }
 
 resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
-  name                 = "ASG-${aws_launch_configuration.bastion_launch_configuration.name}"
-  launch_configuration = aws_launch_configuration.bastion_launch_configuration.name
-  max_size             = var.bastion_instance_count
-  min_size             = var.bastion_instance_count
-  desired_capacity     = var.bastion_instance_count
+  name_prefix = "ASG-${local.name_prefix}"
+  launch_template {
+    id      = aws_launch_template.bastion_launch_template.id
+    version = "$Latest"
+  }
+  max_size         = var.bastion_instance_count
+  min_size         = var.bastion_instance_count
+  desired_capacity = var.bastion_instance_count
 
   vpc_zone_identifier = var.auto_scaling_group_subnets
 
@@ -258,7 +275,7 @@ resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
   ]
 
   tags = concat(
-    list(map("key", "Name", "value", "ASG-${aws_launch_configuration.bastion_launch_configuration.name}", "propagate_at_launch", true)),
+    list(map("key", "Name", "value", "ASG-${local.name_prefix}", "propagate_at_launch", true)),
     local.tags_asg_format
   )
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,30 @@
 output "bastion_host_security_group" {
-  value = aws_security_group.bastion_host_security_group.id
+  value       = aws_security_group.bastion_host_security_group.id
+  description = "The security group ID of the Bastion Host"
 }
 
 output "bucket_kms_key_alias" {
-  value = aws_kms_alias.alias.name
+  value       = aws_kms_alias.alias.name
+  description = "The alias of the buckets kms key"
 }
 
 output "bucket_kms_key_arn" {
-  value = aws_kms_key.key.arn
+  value       = aws_kms_key.key.arn
+  description = "The arn of the buckets kms key"
 }
 
 output "bucket_name" {
-  value = aws_s3_bucket.bucket.bucket
+  value       = aws_s3_bucket.bucket.bucket
+  description = "The name of the bucket where logs are sent"
 }
 
 output "elb_ip" {
-  value = aws_lb.bastion_lb.dns_name
+  value       = aws_lb.bastion_lb.dns_name
+  description = "The ELB DNS Name for the Bastion Host instances"
 }
 
 output "private_instances_security_group" {
-  value = aws_security_group.private_instances_security_group.id
+  value       = aws_security_group.private_instances_security_group.id
+  description = "The security group ID of the the private instances that allow Bastion SSH ingress"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,30 +1,24 @@
 output "bastion_host_security_group" {
-  value       = aws_security_group.bastion_host_security_group.id
-  description = "The security group ID of the Bastion Host"
+  value = aws_security_group.bastion_host_security_group.id
 }
 
 output "bucket_kms_key_alias" {
-  value       = aws_kms_alias.alias.name
-  description = "The alias of the buckets kms key"
+  value = aws_kms_alias.alias.name
 }
 
 output "bucket_kms_key_arn" {
-  value       = aws_kms_key.key.arn
-  description = "The arn of the buckets kms key"
+  value = aws_kms_key.key.arn
 }
 
 output "bucket_name" {
-  value       = aws_s3_bucket.bucket.bucket
-  description = "The name of the bucket where logs are sent"
+  value = aws_s3_bucket.bucket.bucket
 }
 
 output "elb_ip" {
-  value       = aws_lb.bastion_lb.dns_name
-  description = "The ELB DNS Name for the Bastion Host instances"
+  value = aws_lb.bastion_lb.dns_name
 }
 
 output "private_instances_security_group" {
-  value       = aws_security_group.private_instances_security_group.id
-  description = "The security group ID of the the private instances that allow Bastion SSH ingress"
+  value = aws_security_group.private_instances_security_group.id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,21 @@
+output "bastion_host_security_group" {
+  value = aws_security_group.bastion_host_security_group.id
+}
+
+output "bucket_kms_key_alias" {
+  value = aws_kms_alias.alias.name
+}
+
+output "bucket_kms_key_arn" {
+  value = aws_kms_key.key.arn
+}
+
 output "bucket_name" {
   value = aws_s3_bucket.bucket.bucket
 }
 
 output "elb_ip" {
   value = aws_lb.bastion_lb.dns_name
-}
-
-output "bastion_host_security_group" {
-  value = aws_security_group.bastion_host_security_group.id
 }
 
 output "private_instances_security_group" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "bastion_host_security_group" {
-  value = aws_security_group.bastion_host_security_group.id
+  value = aws_security_group.bastion_host_security_group[*].id
 }
 
 output "bucket_kms_key_alias" {

--- a/test/test.tf
+++ b/test/test.tf
@@ -1,19 +1,19 @@
 module "bastion" {
-  "source"                = "../"
-  "bucket_name"           = "my_famous_bucket_name"
-  "region"                = "eu-west-1"
-  "vpc_id"                = "my_vpc_id"
-  "is_lb_private"         = "true"
-  "bastion_host_key_pair" = "my_key_pair"
-  "hosted_zone_id"      = "my.hosted.zone.name."
-  "bastion_record_name"   = "bastion.my.hosted.zone.name."
+  source                = "../"
+  bucket_name           = "my_famous_bucket_name"
+  region                = "eu-west-1"
+  vpc_id                = "my_vpc_id"
+  is_lb_private         = "true"
+  bastion_host_key_pair = "my_key_pair"
+  hosted_zone_id        = "my.hosted.zone.name."
+  bastion_record_name   = "bastion.my.hosted.zone.name."
 
-  "elb_subnets" = [
+  elb_subnets = [
     "subnet-id1a",
     "subnet-id1b",
   ]
 
-  "auto_scaling_group_subnets" = [
+  auto_scaling_group_subnets = [
     "subnet-id1a",
     "subnet-id1b",
   ]

--- a/test/test.tf
+++ b/test/test.tf
@@ -5,7 +5,7 @@ module "bastion" {
   "vpc_id"                = "my_vpc_id"
   "is_lb_private"         = "true"
   "bastion_host_key_pair" = "my_key_pair"
-  "hosted_zone_name"      = "my.hosted.zone.name."
+  "hosted_zone_id"      = "my.hosted.zone.name."
   "bastion_record_name"   = "bastion.my.hosted.zone.name."
 
   "elb_subnets" = [

--- a/user_data.sh
+++ b/user_data.sh
@@ -45,12 +45,16 @@ if [[ -z $SSH_ORIGINAL_COMMAND ]]; then
 
 else
 
-  # The "script" program could be circumvented with some commands (e.g. bash, nc).
-  # Therefore, I intentionally prevent users from supplying commands.
+  # If the module consumer wants to allow remote commands (for ansible or other) then allow that command through.
+  if [ "${allow_ssh_commands}" == "True" ]; then
+    exec /bin/bash -c "$SSH_ORIGINAL_COMMAND"
+  else
+    # The "script" program could be circumvented with some commands (e.g. bash, nc).
+    # Therefore, I intentionally prevent users from supplying commands.
 
-  echo "This bastion supports interactive sessions only. Do not supply a command"
-  exit 1
-
+    echo "This bastion supports interactive sessions only. Do not supply a command"
+    exit 1
+  end
 fi
 
 EOF

--- a/user_data.sh
+++ b/user_data.sh
@@ -171,3 +171,10 @@ cat > ~/mycron << EOF
 EOF
 crontab ~/mycron
 rm ~/mycron
+
+
+#########################################
+## Add Custom extra_user_data_content ##
+#######################################
+
+${extra_user_data_content}

--- a/user_data.sh
+++ b/user_data.sh
@@ -13,6 +13,9 @@ chown ec2-user:ec2-user /var/log/bastion
 chmod -R 770 /var/log/bastion
 setfacl -Rdm other:0 /var/log/bastion
 
+# Update sshd default port to public_ssh_port
+sed -i "s/#Port 22/Port ${public_ssh_port}/g" /etc/ssh/sshd_config
+
 # Make OpenSSH execute a custom script on logins
 echo -e "\\nForceCommand /usr/bin/bastion/shell" >> /etc/ssh/sshd_config
 

--- a/user_data.sh
+++ b/user_data.sh
@@ -54,7 +54,7 @@ else
 
     echo "This bastion supports interactive sessions only. Do not supply a command"
     exit 1
-  end
+  fi
 fi
 
 EOF

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "bastion_host_key_pair" {
   description = "Select the key pair to use to launch the bastion host"
 }
 
-variable "hosted_zone_name" {
+variable "hosted_zone_id" {
   description = "Name of the hosted zone were we'll register the bastion DNS name"
   default     = ""
 }
@@ -76,7 +76,7 @@ variable "bastion_instance_count" {
 }
 
 variable "create_dns_record" {
-  description = "Choose if you want to create a record name for the bastion (LB). If true 'hosted_zone_name' and 'bastion_record_name' are mandatory "
+  description = "Choose if you want to create a record name for the bastion (LB). If true 'hosted_zone_id' and 'bastion_record_name' are mandatory "
 }
 
 variable "log_auto_clean" {

--- a/variables.tf
+++ b/variables.tf
@@ -131,3 +131,8 @@ variable "bastion_iam_policy_name" {
   description = "IAM policy name to create for granting the instance role access to the bucket"
   default     = "BastionHost"
 }
+
+variable "instance_type" {
+  description = "Instance size of the bastion"
+  default     = "t3.nano"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -59,13 +59,13 @@ variable "bastion_launch_template_name" {
 
 variable "bastion_security_group_id" {
   description = "Custom security group to use"
-  default = ""
+  default     = ""
 }
 
 variable "bastion_additional_security_groups" {
- description = "List of additional security groups to attach to the launch template"
- type = list(string)
- default = []
+  description = "List of additional security groups to attach to the launch template"
+  type        = list(string)
+  default     = []
 }
 
 variable "bastion_ami" {

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,8 @@ variable "private_ssh_port" {
   default     = 22
 }
 
+variable "extra_user_data_content" {
+  description = "Additional scripting to pass to the bastion host. For example, this can include installing postgresql for the `psql` command."
+  type = string
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,7 @@ variable "tags" {
 }
 
 variable "region" {
+  description = "AWS Region"
 }
 
 variable "cidrs" {
@@ -74,11 +75,13 @@ variable "auto_scaling_group_subnets" {
 }
 
 variable "associate_public_ip_address" {
-  default = true
+  default     = true
+  description = "Wether or not to associate a public ip"
 }
 
 variable "bastion_instance_count" {
-  default = 1
+  default     = 1
+  description = "Number of instances to create"
 }
 
 variable "create_dns_record" {

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,17 @@ variable "bastion_launch_template_name" {
   default     = "bastion-lt"
 }
 
+variable "bastion_security_group_id" {
+  description = "Custom security group to use"
+  default = ""
+}
+
+variable "bastion_additional_security_groups" {
+ description = "List of additional security groups to attach to the launch template"
+ type = list(string)
+ default = []
+}
+
 variable "bastion_ami" {
   type        = string
   description = "The AMI that the Bastion Host will use."

--- a/variables.tf
+++ b/variables.tf
@@ -114,3 +114,9 @@ variable "extra_user_data_content" {
   type = string
   default = ""
 }
+
+variable "allow_ssh_commands" {
+  description = "Allows the SSH user to execute one-off commands. Pass 'True' to enable. Warning: These commands are not logged and increase the vulnerability of the system. Use at your own discretion."
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -53,8 +53,15 @@ variable "bastion_record_name" {
 }
 
 variable "bastion_launch_configuration_name" {
+  type        = string
   description = "Bastion Launch configuration Name, will also be used for the ASG"
   default     = "lc"
+}
+
+variable "bastion_ami" {
+  type        = string
+  description = "The AMI that the Bastion Host will use."
+  default     = ""
 }
 
 variable "elb_subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "bastion_record_name" {
 
 variable "bastion_launch_template_name" {
   description = "Bastion Launch template Name, will also be used for the ASG"
-  default     = "lt"
+  default     = "bastion-lt"
 }
 
 variable "bastion_ami" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,9 +52,9 @@ variable "bastion_record_name" {
   default     = ""
 }
 
-variable "bastion_launch_configuration_name" {
-  description = "Bastion Launch configuration Name, will also be used for the ASG"
-  default     = "lc"
+variable "bastion_launch_template_name" {
+  description = "Bastion Launch template Name, will also be used for the ASG"
+  default     = "lt"
 }
 
 variable "elb_subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -126,3 +126,8 @@ variable "allow_ssh_commands" {
   type        = string
   default     = ""
 }
+
+variable "bastion_iam_policy_name" {
+  description = "IAM policy name to create for granting the instance role access to the bucket"
+  default     = "BastionHost"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,6 @@ variable "tags" {
 }
 
 variable "region" {
-  description = "AWS Region"
 }
 
 variable "cidrs" {
@@ -75,13 +74,11 @@ variable "auto_scaling_group_subnets" {
 }
 
 variable "associate_public_ip_address" {
-  default     = true
-  description = "Wether or not to associate a public ip"
+  default = true
 }
 
 variable "bastion_instance_count" {
-  default     = 1
-  description = "Number of instances to create"
+  default = 1
 }
 
 variable "create_dns_record" {


### PR DESCRIPTION
This upgrade allows us to:
- specify instance type (defaults to t3.nano - currently running t2.nano)
- have static autoscaling group name prefixes, stops recreating when launch template changes due to AMI ID changes.